### PR TITLE
Audit chunking

### DIFF
--- a/audit-server/src/main/java/com/teamged/auditlogging/LogManager.java
+++ b/audit-server/src/main/java/com/teamged/auditlogging/LogManager.java
@@ -143,8 +143,9 @@ public class LogManager {
                 marshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);
                 marshaller.marshal(jaxbLogType, sw);
 
-                // remove leading "<log>" tag if it's not the first log
                 String logStr = sw.toString();
+
+                // remove leading "<log>" tag if it's not the first log
                 if(!isFirstLog)
                 {
                     logStr = sw.toString().replaceAll("^<log>+", "");
@@ -163,6 +164,13 @@ public class LogManager {
                 if(trimTrailingTag)
                 {
                     logStr = logStr.replaceAll("</log>+$", "");
+                }
+
+                // if the log set is empty, the marshaller has written a self-closing "<log/>" tag which breaks our xml
+                // replace "<log/>" with "</log>"
+                if(logType.getUserCommandOrQuoteServerOrAccountTransaction() == null || logType.getUserCommandOrQuoteServerOrAccountTransaction().size() == 0)
+                {
+                    logStr = logStr.replaceAll("<log/>+$","</log>");
                 }
 
                 // write the edited xml to the file


### PR DESCRIPTION
the audit server will now chunk logs into sets of 100000 and append each set to a file. extra xml tags are trimmed as log sets are appended, then the final closing tag is added after a dumplog executes. There is a minor edge case where if the current log set is exactly 100000 in size when a dumplog executes, the final closing tag is not added.
