### PR TITLE
Comms deployment fixes; tx responses

### DIFF
--- a/deploy-script/src/main/resources/config.json
+++ b/deploy-script/src/main/resources/config.json
@@ -46,7 +46,9 @@
                 "b134.seng.uvic.ca",
                 "b135.seng.uvic.ca",
                 "b136.seng.uvic.ca",
-                "b137.seng.uvic.ca"
+                "b137.seng.uvic.ca",
+                "b142.seng.uvic.ca",
+                "b143.seng.uvic.ca"
             ],
             "port": 44440,
             "internal": {
@@ -90,7 +92,9 @@
                 "b139.seng.uvic.ca",
                 "b153.seng.uvic.ca",
                 "b148.seng.uvic.ca",
-                "b149.seng.uvic.ca"
+                "b149.seng.uvic.ca",
+                "b146.seng.uvic.ca",
+                "b144.seng.uvic.ca"
             ],
             "port": 44449,
             "internal": {

--- a/deploy-script/src/main/resources/run-audit-server.sh
+++ b/deploy-script/src/main/resources/run-audit-server.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd AuditDeploy
-java -cp .:../gson-2.6.2.jar com/teamged/auditserver/AuditMain $HOSTNAME
+java -Xmx2g -cp .:../gson-2.6.2.jar com/teamged/auditserver/AuditMain $HOSTNAME

--- a/deploy-script/src/main/resources/run-proxy-server.sh
+++ b/deploy-script/src/main/resources/run-proxy-server.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd QuoteProxyDeploy
-java -cp .:../gson-2.6.2.jar com/teamged/proxyserver/ProxyMain $HOSTNAME -V
+java -Xmx2g -cp .:../gson-2.6.2.jar com/teamged/proxyserver/ProxyMain $HOSTNAME -V

--- a/deploy-script/src/main/resources/run-tx-server.sh
+++ b/deploy-script/src/main/resources/run-tx-server.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd TransactionDeploy
-java -cp .:../gson-2.6.2.jar com/teamged/txserver/TxMain $HOSTNAME
+java -Xmx2g -cp .:../gson-2.6.2.jar com/teamged/txserver/TxMain $HOSTNAME

--- a/transaction-server/src/main/java/com/teamged/txserver/database/DataProxy.java
+++ b/transaction-server/src/main/java/com/teamged/txserver/database/DataProxy.java
@@ -1,11 +1,8 @@
 package com.teamged.txserver.database;
 
 import com.teamged.logging.Logger;
-import com.teamged.logging.xmlelements.CommandType;
-import com.teamged.logging.xmlelements.SystemEventType;
 import com.teamged.logging.xmlelements.TransactionCompleteType;
 import com.teamged.txserver.InternalLog;
-import com.teamged.txserver.TxMain;
 import com.teamged.txserver.transactions.TransactionObject;
 import com.teamged.txserver.transactions.UserCommand;
 

--- a/transaction-server/src/main/java/com/teamged/txserver/database/UserDatabaseObject.java
+++ b/transaction-server/src/main/java/com/teamged/txserver/database/UserDatabaseObject.java
@@ -4,7 +4,6 @@ import com.teamged.logging.Logger;
 import com.teamged.logging.xmlelements.AccountTransactionType;
 import com.teamged.logging.xmlelements.CommandType;
 import com.teamged.logging.xmlelements.ErrorEventType;
-import com.teamged.logging.xmlelements.SystemEventType;
 import com.teamged.txserver.InternalLog;
 import com.teamged.txserver.TxMain;
 
@@ -1005,25 +1004,6 @@ public class UserDatabaseObject {
 
         long actualValue = stockDollars * 100 + stockCents;
 
-        SystemEventType set = new SystemEventType();
-        set.setCommand(CommandType.BUY);
-        set.setFunds(BigDecimal.valueOf(actualValue, 2));
-        set.setServer(TxMain.getServerName());
-        set.setStockSymbol(stock);
-        set.setTimestamp(Calendar.getInstance().getTimeInMillis());
-        set.setTransactionNum(BigInteger.valueOf(tid));
-        set.setUsername(userName);
-
-        SystemEventType setc = new SystemEventType();
-        setc.setCommand(CommandType.COMMIT_BUY);
-        setc.setServer(TxMain.getServerName());
-        setc.setTransactionNum(BigInteger.valueOf(tid));
-        setc.setUsername(userName);
-        setc.setTimestamp(Calendar.getInstance().getTimeInMillis());
-
-        Logger.getInstance().Log(set);
-        Logger.getInstance().Log(setc);
-
         history.add("BUY," + userName + "," + stock + "," + buy.getDollars() + "." + buy.getCents());
         history.add("COMMIT_BUY," + userName);
     }
@@ -1036,25 +1016,6 @@ public class UserDatabaseObject {
             this.cents -= CENT_CAP;
             this.dollars++;
         }
-
-        SystemEventType set = new SystemEventType();
-        set.setCommand(CommandType.SELL);
-        set.setFunds(BigDecimal.valueOf(actualValue, 2));
-        set.setServer(TxMain.getServerName());
-        set.setStockSymbol(stock);
-        set.setTimestamp(Calendar.getInstance().getTimeInMillis());
-        set.setTransactionNum(BigInteger.valueOf(tid));
-        set.setUsername(userName);
-
-        SystemEventType setc = new SystemEventType();
-        setc.setCommand(CommandType.COMMIT_SELL);
-        setc.setServer(TxMain.getServerName());
-        setc.setTransactionNum(BigInteger.valueOf(tid));
-        setc.setUsername(userName);
-        setc.setTimestamp(Calendar.getInstance().getTimeInMillis());
-
-        Logger.getInstance().Log(set);
-        Logger.getInstance().Log(setc);
 
         history.add("SELL," + userName + "," + stock + "," + sell.getDollars() + "." + sell.getCents());
         history.add("COMMIT_SELL," + userName);

--- a/transaction-server/src/main/java/com/teamged/txserver/transactions/RequestProcessingHandler.java
+++ b/transaction-server/src/main/java/com/teamged/txserver/transactions/RequestProcessingHandler.java
@@ -23,7 +23,7 @@ public class RequestProcessingHandler implements Runnable {
 
     @Override
     public void run() {
-        TransactionObject to = new TransactionObject(serverMessage.getData());
+        TransactionObject to = new TransactionObject(serverMessage);
         if (!to.getErrorString().isEmpty()) {
             InternalLog.Critical("Error processing request: " + to.toString() + "; Error msg: " + to.getErrorString());
             // Even though the transaction is in error, we still need to let the system see it.

--- a/transaction-server/src/main/java/com/teamged/txserver/transactions/TransactionObject.java
+++ b/transaction-server/src/main/java/com/teamged/txserver/transactions/TransactionObject.java
@@ -113,6 +113,7 @@ public class TransactionObject {
                 break;
         }
 
+        /*
         SystemEventType systemEvent = new SystemEventType();
         systemEvent.setTimestamp(System.currentTimeMillis());
         systemEvent.setServer(TxMain.getServerName());
@@ -126,6 +127,7 @@ public class TransactionObject {
         systemEvent.setFunds(new BigDecimal(amountDollars + "." + amountCents));
 
         Logger.getInstance().Log(systemEvent);
+        */
     }
 
     /**

--- a/transaction-server/src/main/java/com/teamged/txserver/transactions/TransactionObject.java
+++ b/transaction-server/src/main/java/com/teamged/txserver/transactions/TransactionObject.java
@@ -1,5 +1,6 @@
 package com.teamged.txserver.transactions;
 
+import com.teamged.comms.ServerMessage;
 import com.teamged.logging.Logger;
 import com.teamged.logging.xmlelements.CommandType;
 import com.teamged.logging.xmlelements.SystemEventType;
@@ -29,7 +30,7 @@ public class TransactionObject {
 
     private static final int StockMaxLength = 3;
 
-    private final String originalArgs;
+    private final ServerMessage serverMessage;
     private UserCommand userCommand = UserCommand.NO_COMMAND;
     private String userName = "";
     private String stockSymbol = "";
@@ -49,12 +50,16 @@ public class TransactionObject {
      * after instantiating this to see if the arguments could be parsed. Any value other than the empty string indicates
      * an error.
      *
-     * @param args The request to parse and process.
+     * @param serverMessage The server request to parse and process.
      */
-    public TransactionObject(String args) {
-        originalArgs = args;
-        parseArgs(args);
-        logRequest();
+    public TransactionObject(ServerMessage serverMessage) {
+        this.serverMessage = serverMessage;
+        if (serverMessage != null) {
+            parseArgs(serverMessage.getData());
+        } else {
+            errorString = "Null server message";
+        }
+        //logRequest();
     }
 
     private void logRequest() {
@@ -113,7 +118,6 @@ public class TransactionObject {
                 break;
         }
 
-        /*
         SystemEventType systemEvent = new SystemEventType();
         systemEvent.setTimestamp(System.currentTimeMillis());
         systemEvent.setServer(TxMain.getServerName());
@@ -127,7 +131,6 @@ public class TransactionObject {
         systemEvent.setFunds(new BigDecimal(amountDollars + "." + amountCents));
 
         Logger.getInstance().Log(systemEvent);
-        */
     }
 
     /**
@@ -451,13 +454,23 @@ public class TransactionObject {
     }
 
     /**
+     * Adds a response to the server message that this transaction was built from. This will queue and eventually
+     * send the response to the original requester.
+     *
+     * @param response The response to send to the requester.
+     */
+    public void sendResponse(String response) {
+        serverMessage.setResponse(response);
+    }
+
+    /**
      * Returns the original request string that this transaction object was built from.
      *
      * @return The string representation of this object.
      */
     @Override
     public String toString() {
-        return originalArgs;
+        return serverMessage != null ? serverMessage.getData() : "";
     }
 
     /**

--- a/transaction-server/src/main/java/com/teamged/txserver/transactions/TransactionProcessingHandler.java
+++ b/transaction-server/src/main/java/com/teamged/txserver/transactions/TransactionProcessingHandler.java
@@ -45,7 +45,8 @@ public class TransactionProcessingHandler implements Runnable {
                         } else {
                             String resp = DataProxy.dbOperation(txObject);
                             System.out.println(txObject.getUserSeqNum() + "[" + txObject.getWorkloadSeqNum() + "]");
-                            InternalLog.Log(resp);   // TODO: Handle the response.
+                            InternalLog.Log(resp);
+                            txObject.sendResponse(resp); // Queues the response to send back to the client
                         }
 
                         count--;


### PR DESCRIPTION
Extra logs are removed for purposes of being able to upload to verification server.

Tx, Proxy, and Audit servers are run with greater heap space to support large buffering
Tx server now properly sends responses to the web server. This resolves #12 

This pull request should remain open until testing is completed
